### PR TITLE
feat: implement Basic1Up component

### DIFF
--- a/components/Basic1Up/Basic1Up.examples.ts
+++ b/components/Basic1Up/Basic1Up.examples.ts
@@ -1,0 +1,27 @@
+import type { IBasic1Up } from "./Basic1Up.types";
+
+const BASIC_1_UP_DEFAULT_PROPS: IBasic1Up = {
+  alignment: "left",
+  blockquote:
+    "Most clients save 30-50% compared to Pantheon or Acquia while receiving better performance.",
+  description:
+    "High-performance hosting for Drupal and WordPress that scales with your success, not against it. Fixed, predictable pricing with direct access to experts. Get the advanced infrastructure you needs at a fraction of the cost.",
+  eyebrow: "Our platform",
+  image: {
+    alt: "Placeholder image",
+    src: "https://picsum.photos/562/568",
+  },
+  primaryCTA: {
+    children: "Schedule a demo",
+    href: "/",
+  },
+  secondaryCTA: {
+    children: "Learn more",
+    href: "/",
+  },
+  title: "Enterprise Performance Without Enterprise Pricing",
+};
+
+export const BASIC_1_UP_EXAMPLE_PROPS = {
+  default: BASIC_1_UP_DEFAULT_PROPS,
+};

--- a/components/Basic1Up/Basic1Up.stories.tsx
+++ b/components/Basic1Up/Basic1Up.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { Basic1Up } from "./Basic1Up";
+import { BASIC_1_UP_EXAMPLE_PROPS } from "./Basic1Up.examples";
+
+const meta: Meta<typeof Basic1Up> = {
+  title: "Organisms/Basic 1-Up",
+  component: Basic1Up,
+  parameters: { layout: "fullscreen" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Basic1Up>;
+
+export const Default: Story = { args: BASIC_1_UP_EXAMPLE_PROPS.default };

--- a/components/Basic1Up/Basic1Up.tsx
+++ b/components/Basic1Up/Basic1Up.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Container } from "@/components/Container/Container";
+import { cn } from "@/utils/classes";
+import Image from "next/image";
+import type { HTMLAttributes } from "react";
+import { ContentBlock } from "../ContentBlock/ContentBlock";
+import { DottedBackground } from "../DottedBackground/DottedBackground";
+import type { IBasic1Up } from "./Basic1Up.types";
+
+const dottedBgClasses = [
+  "px-6 pt-21 size-full relative max-md:-left-5 max-md:w-screen md:col-span-6 md:w-[calc(100%+1.25rem)] lg:pt-16.5 2xl:p-20 2xl:pb-0",
+  "before:bg-deep-green-5 before:content-[''] before:absolute before:inset-0 before:-z-10 before:size-full",
+];
+
+const figureClasses = [
+  "aspect-[345/309] object-cover relative flex items-end lg:aspect-[464/470] 2xl:aspect-[562/568]",
+  "relative h-auto w-full",
+];
+
+export const Basic1Up = ({
+  alignment,
+  blockquote,
+  description,
+  eyebrow,
+  image,
+  primaryCTA,
+  secondaryCTA,
+  title,
+  ...props
+}: IBasic1Up) => {
+  const isLeft = alignment === "left";
+
+  const Asset = ({ className, ...props }: HTMLAttributes<HTMLDivElement>) => {
+    if (!image) return null;
+
+    return (
+      <DottedBackground className={cn(dottedBgClasses, className)}>
+        <div className="flex items-end size-full">
+          <figure className={cn(figureClasses)} {...props}>
+            <Image
+              {...image}
+              className="object-cover"
+              fill
+              sizes="(max-width: 1024px) 100vw, 50vw"
+            />
+          </figure>
+        </div>
+      </DottedBackground>
+    );
+  };
+
+  return (
+    <Container {...props} displays={{ md: "grid" }} noPadding>
+      {!isLeft && <Asset className="max-md:hidden md:-mr-5" />}
+      <ContentBlock
+        blockquote={blockquote}
+        blockquoteClassName="my-6 lg:my-8"
+        className={cn(
+          "md:col-span-6 py-12 lg:p-10 2xl:px-16 2xl:py-25",
+          isLeft ? "md:-mr-5" : "md:-ml-5",
+        )}
+        description={description}
+        descriptionClassName="lg:max-xl:text-base"
+        eyebrow={eyebrow}
+        eyebrowVariant="highlight"
+        primaryCTA={primaryCTA}
+        secondaryCTA={secondaryCTA}
+        title={title}
+        titleClassName="py-4 md:py-5"
+      />
+      <Asset className={cn("md:-ml-5", !isLeft && "md:hidden")} />
+    </Container>
+  );
+};

--- a/components/Basic1Up/Basic1Up.types.ts
+++ b/components/Basic1Up/Basic1Up.types.ts
@@ -1,0 +1,49 @@
+import type { ICTA } from "@/types/cta.types";
+import type { IImage } from "@/types/image.types";
+import type { HTMLAttributes } from "react";
+
+/**
+ * Alignment options for the Basic1Up component.
+ */
+export type TBasic1UpAlignment = "left" | "right";
+
+/**
+ * Props for the Basic1Up component.
+ */
+export interface IBasic1Up extends HTMLAttributes<HTMLElement> {
+  /**
+   * Determines the visual alignment of the component.
+   * Defaults to `left` if not specified.
+   */
+  alignment?: TBasic1UpAlignment;
+
+  /**
+   * Blockquote text displayed within the component.
+   */
+  blockquote?: string;
+
+  /**
+   * Short description text displayed within or alongside the component.
+   */
+  description?: string;
+
+  /**
+   * A small piece of text, often used as a label or category indicator.
+   */
+  eyebrow?: string;
+
+  /**
+   * Image displayed within the component.
+   */
+  image: IImage;
+
+  /**
+   * Primary call-to-action button.
+   */
+  primaryCTA?: ICTA;
+
+  /**
+   * Secondary call-to-action button.
+   */
+  secondaryCTA?: ICTA;
+}


### PR DESCRIPTION
# Implement Basic1Up component with default props and Storybook integration

## What's in this PR
This PR introduces the **Basic1Up** component.

### Key Features
- Alignment options (**left** or **right**) for layout flexibility  
- Integrated **ContentBlock** with support for:
  - Eyebrow and title text  
  - Description and blockquote text  
  - Primary and secondary CTA buttons
- **Storybook integration** with default example props  

### Technical Details
- Image layout ratios use:  
  `aspect-[345/309]`, `lg:aspect-[464/470]`, and `2xl:aspect-[562/568]` for consistent scaling  
- Content and asset sections are conditionally rendered based on alignment  
- Includes reusable example props for documentation and previews  

