### PR TITLE
feat: implement LogoMarquee component

### DIFF
--- a/components/LogoMarquee/LogoMarquee.examples.ts
+++ b/components/LogoMarquee/LogoMarquee.examples.ts
@@ -1,0 +1,33 @@
+import type { ILogoMarquee } from "./LogoMarquee.types";
+
+const LOGO_MARQUEE_DEFAULT_PROPS: ILogoMarquee = {
+  description:
+    "Invest in your growth and success ——— Trusted by our beloved clients",
+  logos: [
+    {
+      alt: "Client Logo 1",
+      src: "https://picsum.photos/131/67",
+      width: 131,
+      height: 67,
+      priority: true,
+    },
+    {
+      alt: "Client Logo 2",
+      src: "https://picsum.photos/110/54",
+      width: 110,
+      height: 54,
+      priority: true,
+    },
+    {
+      alt: "Client Logo 3",
+      src: "https://picsum.photos/145/60",
+      width: 145,
+      height: 60,
+      priority: true,
+    },
+  ],
+};
+
+export const LOGO_MARQUEE_EXAMPLE_PROPS = {
+  default: LOGO_MARQUEE_DEFAULT_PROPS,
+};

--- a/components/LogoMarquee/LogoMarquee.stories.tsx
+++ b/components/LogoMarquee/LogoMarquee.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { LogoMarquee } from "./LogoMarquee";
+import { LOGO_MARQUEE_EXAMPLE_PROPS } from "./LogoMarquee.examples";
+
+const meta: Meta<typeof LogoMarquee> = {
+  title: "Organisms/Logo Marquee",
+  component: LogoMarquee,
+  parameters: { layout: "fullscreen" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof LogoMarquee>;
+export const Default: Story = { args: LOGO_MARQUEE_EXAMPLE_PROPS.default };

--- a/components/LogoMarquee/LogoMarquee.tsx
+++ b/components/LogoMarquee/LogoMarquee.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { Container } from "@/components/Container/Container";
+import { cn } from "@/utils/classes";
+import Image from "next/image";
+import { useLayoutEffect, useRef, useState } from "react";
+import Marquee from "react-fast-marquee";
+import type { ILogoMarquee } from "./LogoMarquee.types";
+
+export const LogoMarquee = ({
+  className,
+  description,
+  logos,
+  ...props
+}: ILogoMarquee) => {
+  const marqueeRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [shouldScroll, setShouldScroll] = useState(false);
+
+  useLayoutEffect(() => {
+    if (!marqueeRef.current || !contentRef.current) return;
+    const container = marqueeRef.current;
+    const content = contentRef.current;
+    if (container.offsetWidth < content.scrollWidth) {
+      setShouldScroll(true);
+    } else {
+      setShouldScroll(false);
+    }
+  }, [logos]);
+
+  const renderLogos = (extraClass = "") => (
+    <div
+      className={cn(
+        "logo-marquee-inner flex gap-x-12 items-center",
+        extraClass,
+      )}
+      ref={contentRef}
+    >
+      {logos.map((logo, idx) => (
+        <div className="flex items-center" key={logo.alt || idx}>
+          <Image
+            alt={logo.alt || "Logo"}
+            className="object-contain h-12 w-auto min-w-fit"
+            height={logo.height || 60}
+            priority={logo.priority}
+            src={logo.src}
+            width={logo.width || 120}
+          />
+        </div>
+      ))}
+    </div>
+  );
+
+  return (
+    <Container
+      className={cn("py-16 text-center", className)}
+      noPadding
+      {...props}
+    >
+      {description && (
+        <p className="mb-8.5 font-mono text-sm uppercase">{description}</p>
+      )}
+      <div className="overflow-x-hidden w-full" ref={marqueeRef}>
+        {logos &&
+          logos.length > 0 &&
+          (shouldScroll ? (
+            <Marquee gradient={false} pauseOnHover speed={40}>
+              {renderLogos()}
+            </Marquee>
+          ) : (
+            renderLogos("justify-center")
+          ))}
+      </div>
+    </Container>
+  );
+};

--- a/components/LogoMarquee/LogoMarquee.types.ts
+++ b/components/LogoMarquee/LogoMarquee.types.ts
@@ -1,0 +1,17 @@
+import type { IImage } from "@/types/image.types";
+import type { HTMLAttributes } from "react";
+
+/**
+ * Props for the LogoMarquee component.
+ */
+export interface ILogoMarquee extends HTMLAttributes<HTMLElement> {
+  /**
+   * Short description text displayed within or alongside the component.
+   */
+  description?: string;
+
+  /**
+   * Array of logo images to be displayed in the marquee.
+   */
+  logos: IImage[];
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "next-themes": "^0.4.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-fast-marquee": "^1.6.5",
         "tailwind-merge": "^3.3.1",
         "tailwind-variants": "^3.1.1",
         "yaml": "^2.8.1",
@@ -9082,6 +9083,16 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-fast-marquee": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/react-fast-marquee/-/react-fast-marquee-1.6.5.tgz",
+      "integrity": "sha512-swDnPqrT2XISAih0o74zQVE2wQJFMvkx+9VZXYYNSLb/CUcAzU9pNj637Ar2+hyRw6b4tP6xh4GQZip2ZCpQpg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">= 16.8.0 || ^18.0.0",
+        "react-dom": ">= 16.8.0 || ^18.0.0"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "next-themes": "^0.4.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-fast-marquee": "^1.6.5",
     "tailwind-merge": "^3.3.1",
     "tailwind-variants": "^3.1.1",
     "yaml": "^2.8.1",


### PR DESCRIPTION
### Implement LogoMarquee component with default props and examples  

#### What's in this PR
This PR introduces the LogoMarquee component, a logo carousel for showcasing client or partner logos. The component automatically determines whether to scroll the logos (marquee effect) or display them statically, based on container overflow.
