### PR TITLE
feat: Implement FeaturedText component with example props and stories

### DIFF
--- a/components/FeaturedText/FeaturedText.examples.ts
+++ b/components/FeaturedText/FeaturedText.examples.ts
@@ -1,0 +1,11 @@
+import type { IFeaturedText } from "./FeaturedText.types";
+
+const FEATURED_TEXT_DEFAULT_PROPS: IFeaturedText = {
+  description:
+    "Our senior developers and architects are just a Slack message away. Cut through the bureaucracy. <strong>Stop paying enterprise rates to talk to people who can't even read your code.</strong>",
+  eyebrow: "A personal touch",
+};
+
+export const FEATURED_TEXT_EXAMPLE_PROPS = {
+  default: FEATURED_TEXT_DEFAULT_PROPS,
+};

--- a/components/FeaturedText/FeaturedText.stories.tsx
+++ b/components/FeaturedText/FeaturedText.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { FeaturedText } from "./FeaturedText";
+import { FEATURED_TEXT_EXAMPLE_PROPS } from "./FeaturedText.examples";
+
+const meta: Meta<typeof FeaturedText> = {
+  title: "Organisms/Featured Text",
+  component: FeaturedText,
+  parameters: { layout: "fullscreen" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof FeaturedText>;
+export const Default: Story = { args: FEATURED_TEXT_EXAMPLE_PROPS.default };

--- a/components/FeaturedText/FeaturedText.tsx
+++ b/components/FeaturedText/FeaturedText.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Container } from "@/components/Container/Container";
+import { ContentBlock } from "../ContentBlock/ContentBlock";
+import { DottedBackground } from "../DottedBackground/DottedBackground";
+import type { IFeaturedText } from "./FeaturedText.types";
+
+export const FeaturedText = ({
+  className,
+  description,
+  eyebrow,
+  ...props
+}: IFeaturedText) => {
+  return (
+    <Container className={className} {...props}>
+      <DottedBackground className="border-x border-border-normal py-16 lg:py-30 w-full">
+        <ContentBlock
+          className="max-w-207 mx-auto"
+          description={description}
+          descriptionClassName="text-size-24 font-light lg:text-size-24 [&_strong]:font-semibold"
+          eyebrow={eyebrow}
+          eyebrowClassName="mb-6"
+          eyebrowVariant="highlight"
+          variant="center"
+        />
+      </DottedBackground>
+    </Container>
+  );
+};

--- a/components/FeaturedText/FeaturedText.types.ts
+++ b/components/FeaturedText/FeaturedText.types.ts
@@ -1,0 +1,16 @@
+import type { HTMLAttributes } from "react";
+
+/**
+ * Props for the FeaturedText component.
+ */
+export interface IFeaturedText extends HTMLAttributes<HTMLElement> {
+  /**
+   * Short description text displayed within or alongside the component.
+   */
+  description?: string;
+
+  /**
+   * Eyebrow text displayed above the title, often used for categorization or emphasis.
+   */
+  eyebrow?: string;
+}


### PR DESCRIPTION
# Implement FeaturedText Component

This pull request introduces the **`FeaturedText`** component — a reusable section for highlighting concise, impactful messaging with an eyebrow and description.

## Included
- `FeaturedText` component implementation  
- Example props via `FeaturedText.examples.ts`  
- Storybook story under **Organisms / Featured Text**  
- Type definitions for `IFeaturedText`