### PR TITLE
feat: lmplement RelatedPosts component with example props and stories

### DIFF
--- a/components/RelatedPosts/RelatedPosts.examples.ts
+++ b/components/RelatedPosts/RelatedPosts.examples.ts
@@ -1,0 +1,22 @@
+import { RESOURCE_CARD_EXAMPLE_PROPS } from "../ResourceCard/ResourceCard.examples";
+import type { IRelatedPosts } from "./RelatedPosts.types";
+
+const RELATED_POSTS_DEFAULT_PROPS: IRelatedPosts = {
+  items: [
+    RESOURCE_CARD_EXAMPLE_PROPS.default,
+    RESOURCE_CARD_EXAMPLE_PROPS.default,
+    RESOURCE_CARD_EXAMPLE_PROPS.default,
+  ].map((item, index) => ({
+    ...item,
+    className: "",
+    image: {
+      src: `https://picsum.photos/1000/1000?random=${index}`,
+      alt: `Related Post Example Image ${index + 1}`,
+    },
+  })),
+  title: "Related Posts",
+};
+
+export const RELATED_POSTS_EXAMPLE_PROPS = {
+  default: RELATED_POSTS_DEFAULT_PROPS,
+};

--- a/components/RelatedPosts/RelatedPosts.stories.tsx
+++ b/components/RelatedPosts/RelatedPosts.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { RelatedPosts } from "./RelatedPosts";
+import { RELATED_POSTS_EXAMPLE_PROPS } from "./RelatedPosts.examples";
+
+const meta: Meta<typeof RelatedPosts> = {
+  title: "Organisms/Related Posts",
+  component: RelatedPosts,
+  parameters: { layout: "fullscreen" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof RelatedPosts>;
+export const Default: Story = { args: RELATED_POSTS_EXAMPLE_PROPS.default };

--- a/components/RelatedPosts/RelatedPosts.tsx
+++ b/components/RelatedPosts/RelatedPosts.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { Container } from "@/components/Container/Container";
+import { cn } from "@/utils";
+import { ResourceCard } from "../ResourceCard/ResourceCard";
+import type { IRelatedPosts } from "./RelatedPosts.types";
+
+export const RelatedPosts = ({
+  className,
+  items,
+  title,
+  ...props
+}: IRelatedPosts) => {
+  return (
+    <Container {...props} className={cn("mb-10", className)} noPadding>
+      <Container className="border-b border-border-normal">
+        <h2 className="border-x border-border-normal font-medium font-mono px-5 py-6 uppercase lg:px-8">
+          {title}
+        </h2>
+      </Container>
+      <Container
+        className="border-b border-border-normal"
+        displays={{ lg: "flex" }}
+      >
+        {items.map((item, index) => (
+          <Container
+            className="border-border-normal last:border-b-0 max-lg:border-b lg:first:border-l lg:last:border-r"
+            key={index}
+            noPadding
+          >
+            <ResourceCard
+              {...item}
+              className="w-full max-lg:border-b max-lg:border-border-normal max-lg:last:border-b-0 md:max-lg:border-x"
+            />
+          </Container>
+        ))}
+      </Container>
+    </Container>
+  );
+};

--- a/components/RelatedPosts/RelatedPosts.types.ts
+++ b/components/RelatedPosts/RelatedPosts.types.ts
@@ -1,0 +1,12 @@
+import type { HTMLAttributes } from "react";
+import type { IResourceCard } from "../ResourceCard/ResourceCard.types";
+
+/**
+ * Props for the RelatedPosts component.
+ */
+export interface IRelatedPosts extends HTMLAttributes<HTMLElement> {
+  /**
+   * Array of related resource cards to display.
+   */
+  items: IResourceCard[];
+}


### PR DESCRIPTION
## Feature: RelatedPosts Component

This PR introduces the **RelatedPosts** component — a reusable section that displays related articles or resources in a clean, bordered layout consistent with the site’s visual system.

---

### Component Overview

#### **RelatedPosts**
- Displays a titled section with a horizontal list of resource cards.
- Responsive layout:
  - Stacked layout on smaller screens.
  - Three-column layout on large screens.
- Styled with consistent borders and spacing using the `Container` component.
- Accepts any `ResourceCard` data to maintain flexibility across resource types.