### PR TITLE
feat: Implement DetailsAside component with example props and types

### DIFF
--- a/components/DetailsAside/DetailsAside.examples.ts
+++ b/components/DetailsAside/DetailsAside.examples.ts
@@ -1,0 +1,22 @@
+import type { IDetailsAside } from "./DetailsAside.types";
+
+const DETAILS_ASIDE_DEFAULT_PROPS: IDetailsAside = {
+  cta: {
+    children: "View Live Website",
+    href: "https://www.example.com",
+  },
+  details: [
+    {
+      label: "Services",
+      items: ["UI/UX Design", "Drupal", "A/B Testing"],
+    },
+    {
+      label: "Industry",
+      items: ["Publishing"],
+    },
+  ],
+};
+
+export const DETAILS_ASIDE_EXAMPLE_PROPS = {
+  default: DETAILS_ASIDE_DEFAULT_PROPS,
+};

--- a/components/DetailsAside/DetailsAside.stories.tsx
+++ b/components/DetailsAside/DetailsAside.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/nextjs-vite";
+import { DetailsAside } from "./DetailsAside";
+import { DETAILS_ASIDE_EXAMPLE_PROPS } from "./DetailsAside.examples";
+
+const meta: Meta<typeof DetailsAside> = {
+  title: "Molecules/Details Aside",
+  component: DetailsAside,
+  parameters: { layout: "full-centered" },
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof DetailsAside>;
+export const Default: Story = { args: DETAILS_ASIDE_EXAMPLE_PROPS.default };

--- a/components/DetailsAside/DetailsAside.tsx
+++ b/components/DetailsAside/DetailsAside.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { cn } from "@/utils/classes";
+import { Button } from "../Button/Button";
+import type { IDetailsAside } from "./DetailsAside.types";
+
+export const DetailsAside = ({
+  className,
+  cta,
+  details,
+  ...props
+}: IDetailsAside) => {
+  return (
+    <aside className={cn("", className)} {...props}>
+      {cta && <Button {...cta} variant="outline" />}
+
+      {details.map(({ label, items }) => (
+        <div className="pt-20" key={label}>
+          <h2 className="font-medium font-mono uppercase">{label}</h2>
+          <ul className="leading-[1.5] text-default-heading text-size-24 tracking-[0.01em]">
+            {items.map((item) => (
+              <li className="mt-5" key={item}>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ))}
+    </aside>
+  );
+};

--- a/components/DetailsAside/DetailsAside.types.ts
+++ b/components/DetailsAside/DetailsAside.types.ts
@@ -1,0 +1,22 @@
+import type { ICTA } from "@/types/cta.types";
+import type { HTMLAttributes } from "react";
+
+export interface IDetailAsideDetail {
+  label: string;
+  items: string[];
+}
+
+/**
+ * Props for the DetailsAside component.
+ */
+export interface IDetailsAside extends HTMLAttributes<HTMLElement> {
+  /**
+   * Call to action object containing text and URL.
+   */
+  cta?: ICTA;
+
+  /**
+   * Details to be displayed in the aside.
+   */
+  details: IDetailAsideDetail[];
+}


### PR DESCRIPTION
## Feature: DetailsAside Component

This PR introduces the **DetailsAside** component — a sidebar section designed to display structured project or article metadata alongside a call-to-action button.

---

### Component Overview

#### **DetailsAside**
- Displays grouped metadata such as “Services” and “Industry.”
- Supports an optional **CTA** button for external links (e.g., “View Live Website”).
- Accepts any detail labels and items for flexible reuse across pages.