### PR TITLE
fix: add dark mode styles to mobile and desktop gradients in PageFooter

### DIFF
--- a/components/PageFooter/PageFooter.tsx
+++ b/components/PageFooter/PageFooter.tsx
@@ -11,8 +11,8 @@ const styles = {
     "flex items-center justify-center relative flex-col overflow-hidden",
   description: "text-default-base",
   title: "mb-3",
-  mobileGradient: "absolute top-0 lg:hidden",
-  desktopGradient: "absolute top-0 max-lg:hidden",
+  mobileGradient: "absolute top-0 lg:hidden dark:mix-blend-color-dodge",
+  desktopGradient: "absolute top-0 max-lg:hidden dark:mix-blend-color-dodge",
   dottedBackground: "z-20 relative h-full",
   gradientBg:
     "bg-gradient-to-b from-brand-aqua/20 via-page-default via-60% to-page-default h-full z-10 relative",


### PR DESCRIPTION
This PR updates the PageFooter background gradients to improve rendering in dark mode.

### Changes
- Applied `mix-blend-color-dodge` to mobile and desktop gradient layers in dark mode