### PR TITLE
fix: update link style in Navigation component

### DIFF
--- a/components/Navigation/Navigation.tsx
+++ b/components/Navigation/Navigation.tsx
@@ -11,7 +11,7 @@ import type { INavigation } from "./Navigation.types";
 const styles = {
   container:
     "flex items-center justify-between max-w-540 mx-auto px-5 py-3 sticky top-0 bg-page-default w-full z-30 before:absolute before:border-b before:border-border-normal before:w-screen before:bottom-0 before:left-1/2 before:-translate-x-1/2",
-  link: "text-interactive-nav",
+  link: "text-interactive-nav font-normal",
   list: "flex gap-x-4 xl:gap-x-8",
   logo: "h-8 max-w-39.5 relative w-full lg:h-9",
 };


### PR DESCRIPTION
This PR updates the Navigation link styles to ensure consistent font weight.

### Changes
- Explicitly set `font-normal` on navigation links
- Prevents unintended font weight inheritance across themes and layouts
