### PR TITLE
refactor: update font variables in globals.css and layout.tsx

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -29,8 +29,8 @@
   --text-size-66: 4.125rem;
   --text-size-64: 4rem;
   --text-size-80: 5rem;
-  --font-family-sans: Geist, system-ui, sans-serif;
-  --font-family-mono: "Geist Mono", "Courier New", monospace;
+  --font-sans: var(--font-geist);
+  --font-mono: var(--font-geist-mono);
 
   /* Black Colors */
   --color-black-5: rgba(17, 17, 17, 0.05);
@@ -168,7 +168,7 @@
 body {
   background-color: var(--color-page-default);
   color: var(--color-default-base);
-  font-family: var(--font-family-sans);
+  font-family: var(--font-geist-mono);
   font-weight: 300;
   line-height: 1.5;
   max-width: var(--breakpoint-5xl);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,8 +24,12 @@ export default function RootLayout({
   const navigationData = loadNavigationData();
 
   return (
-    <html lang="en" suppressHydrationWarning>
-      <body className={cn(geist.variable, geistMono.variable, "antialiased")}>
+    <html
+      className={cn(geist.variable, geistMono.variable, "antialiased")}
+      lang="en"
+      suppressHydrationWarning
+    >
+      <body>
         <ThemeProvider
           attribute="data-theme"
           defaultTheme="system"


### PR DESCRIPTION
This PR refactors global font variables and updates how Geist fonts are applied across the app.

### Changes
- Renamed font CSS variables to align with Geist font tokens (`--font-sans`, `--font-mono`)
- Updated `globals.css` to reference the new font variables
- Applied Geist and Geist Mono variables at the root layout level
